### PR TITLE
Fix utf8 decode error with replace policy

### DIFF
--- a/dlt/helpers.py
+++ b/dlt/helpers.py
@@ -59,6 +59,6 @@ def bytes_to_str(byte_or_str):
     """Return string from bytes"""
     if six.PY3:
         if isinstance(byte_or_str, bytes):
-            return byte_or_str.decode('utf8')
+            return byte_or_str.decode('utf8', errors="replace")
 
     return str(byte_or_str)


### PR DESCRIPTION
If the payload contains non-utf8 character, it would cause DLTMessage.payload_decoded to raise an exception.

For resolving the problem, the patch adds error policy for string decoding.