### PR TITLE
Get the time from dlt messages for DTLBroker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ build-image:
 	docker build --build-arg LIBDLT_VERSION=${LIBDLT_VERSION} \
 		--tag ${IMAGE}:${LIBDLT_VERSION} .
 
+.PHONY: bash
+bash:
+	${DK_CMD} -it ${IMAGE}:${TAG}
+
 .PHONY: clean
 clean:
 ifeq (,$(wildcard /.dockerenv))

--- a/dlt/dlt.py
+++ b/dlt/dlt.py
@@ -239,6 +239,8 @@ class DLTMessage(cDLTMessage, MessageMode):
     # object is not initialized if the message is loaded from a file
     initialized_as_object = False
 
+    re_pattern_type = type(re.compile(r"type"))
+
     def __init__(self, *args, **kwords):
         self.initialized_as_object = True
         self.verbose = kwords.pop("verbose", 0)
@@ -429,15 +431,13 @@ class DLTMessage(cDLTMessage, MessageMode):
             raise TypeError("other must be instance of mgu_dlt.dlt.DLTMessage, mgu_dlt.dlt.DLTFilter or a dictionary"
                             " found: {}".format(type(other)))
 
-        re_pattern_type = type(re.compile(r"type"))
-
         other = other.copy()
         apid = other.get("apid", None)
-        if apid and not isinstance(apid, re_pattern_type) and self.apid != apid:
+        if apid and not isinstance(apid, self.re_pattern_type) and self.apid != apid:
             return False
 
         ctid = other.get("ctid", None)
-        if ctid and not isinstance(ctid, re_pattern_type) and self.ctid != ctid:
+        if ctid and not isinstance(ctid, self.re_pattern_type) and self.ctid != ctid:
             return False
 
         for key, val in other.items():
@@ -447,7 +447,7 @@ class DLTMessage(cDLTMessage, MessageMode):
             msg_val = getattr(self, key, b"")
             if not msg_val:
                 return False
-            if isinstance(val, re_pattern_type):
+            if isinstance(val, self.re_pattern_type):
                 if not val.search(msg_val):
                     return False
             elif msg_val != val:

--- a/dlt/dlt_broker.py
+++ b/dlt/dlt_broker.py
@@ -93,7 +93,7 @@ class DLTBroker(object):
 
     def stop(self):
         """Stop the broker"""
-        logger.info("Stopping DLTContextHandler, DLTTimeHandler and DLTMessageHandler")
+        logger.info("Stopping DLTContextHandler and DLTMessageHandler")
 
         logger.debug("Stop DLTMessageHandler")
         self.mp_stop_flag.set()

--- a/dlt/dlt_broker.py
+++ b/dlt/dlt_broker.py
@@ -1,14 +1,13 @@
 # Copyright (C) 2015. BMW Car IT GmbH. All rights reserved.
 """DLT Broker is running in a loop in a separate thread until stop_flag is set and adding received messages
 to all registered queues"""
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import ipaddress as ip
 import logging
-
 from multiprocessing import Event, Queue
 
-from dlt.dlt_broker_handlers import DLT_DAEMON_TCP_PORT, DLTContextHandler, DLTMessageHandler
+from dlt.dlt_broker_handlers import DLT_DAEMON_TCP_PORT, DLTContextHandler, DLTMessageHandler, DLTTimeValue
 
 DLT_CLIENT_TIMEOUT = 5
 
@@ -19,25 +18,31 @@ class DLTBroker(object):
     """DLT Broker class manages receiving and filtering of DLT Messages
     """
 
-    def __init__(self, ip_address, port=DLT_DAEMON_TCP_PORT, use_proxy=False, **kwargs):
+    def __init__(self, ip_address, port=DLT_DAEMON_TCP_PORT, use_proxy=False,
+                 enable_dlt_time=False, **kwargs):
         """Initialize the DLT Broker
 
         :param str ip_address: IP address of the DLT Daemon. Defaults to TCP connection, unless a multicast address is
         used. In that case an UDP multicast connection will be used
         :param str post: Port of the DLT Daemon
         :param bool use_proxy: Ignored - compatibility option
+        :param bool enable_dlt_time: Record the latest dlt message timestamp if enabled.
         :param **kwargs: All other args passed to DLTMessageHandler
         """
 
+        # - dlt-time share memory init
+        self._dlt_time_value = DLTTimeValue() if enable_dlt_time else None
+
         # - handlers init
         self.mp_stop_flag = Event()
-
         self.filter_queue = Queue()
         self.message_queue = Queue()
         kwargs["ip_address"] = ip_address
         kwargs["port"] = port
         kwargs["timeout"] = kwargs.get("timeout", DLT_CLIENT_TIMEOUT)
-        self.msg_handler = DLTMessageHandler(self.filter_queue, self.message_queue, self.mp_stop_flag, kwargs)
+        self.msg_handler = DLTMessageHandler(
+            self.filter_queue, self.message_queue, self.mp_stop_flag, kwargs, dlt_time_value=self._dlt_time_value,
+        )
         self.context_handler = DLTContextHandler(self.filter_queue, self.message_queue)
 
         self._ip_address = ip_address
@@ -49,6 +54,9 @@ class DLTBroker(object):
         logger.debug(
             "Starting DLTBroker with parameters: use_proxy=%s, ip_address=%s, port=%s, filename=%s, multicast=%s",
             False, self._ip_address, self._port, self._filename, ip.ip_address(self._ip_address).is_multicast)
+
+        if self._dlt_time_value:
+            logger.debug("Enable dlt time for DLTBroker.")
 
         self.msg_handler.start()
         self.context_handler.start()
@@ -85,14 +93,18 @@ class DLTBroker(object):
 
     def stop(self):
         """Stop the broker"""
-        logger.info("Stopping DLTContextHandler and DLTMessageHandler")
+        logger.info("Stopping DLTContextHandler, DLTTimeHandler and DLTMessageHandler")
 
-        # - stop the DLTMessageHandler process and DLTContextHandler thread
+        logger.debug("Stop DLTMessageHandler")
         self.mp_stop_flag.set()
+
+        logger.debug("Stop DLTContextHandler")
         self.context_handler.stop()
 
-        logger.debug("Waiting on DLTContextHandler and DLTMessageHandler")
+        logger.debug("Waiting on DLTContextHandler ending")
         self.context_handler.join()
+
+        logger.debug("Waiting on DLTMessageHandler ending")
         if self.msg_handler.is_alive():
             try:
                 self.msg_handler.terminate()
@@ -100,6 +112,7 @@ class DLTBroker(object):
                 pass
             else:
                 self.msg_handler.join()
+
         logger.debug("DLTBroker execution done")
 
     # pylint: disable=invalid-name
@@ -110,3 +123,15 @@ class DLTBroker(object):
         need to be replaced in MTEE eventually.
         """
         return any((self.msg_handler.is_alive(), self.context_handler.is_alive()))
+
+    def dlt_time(self):
+        """Get time for the last dlt message
+
+        The value is seconds from 1970/1/1 0:00:00
+
+        :rtype: float
+        """
+        if self._dlt_time_value:
+            return self._dlt_time_value.timestamp
+
+        raise RuntimeError("Getting dlt time function is not enabled")

--- a/tests/dlt_broker_time_tests.py
+++ b/tests/dlt_broker_time_tests.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021. BMW Car IT GmbH. All rights reserved.
-"""Test DLTTimeHandler"""
+"""Test DLTBroker with enabling dlt_time"""
 from contextlib import contextmanager
 import itertools
 import time

--- a/tests/dlt_broker_time_tests.py
+++ b/tests/dlt_broker_time_tests.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2021. BMW Car IT GmbH. All rights reserved.
+"""Test DLTTimeHandler"""
+from contextlib import contextmanager
+import itertools
+import time
+
+from nose.tools import assert_false, assert_is_none, assert_is_not_none, assert_raises, assert_true, eq_
+from parameterized import parameterized
+import six
+
+from dlt.dlt_broker import DLTBroker
+from dlt.dlt_broker_handlers import DLTMessageHandler
+from tests.utils import MockDLTMessage
+
+if six.PY2:
+    from mock import patch, MagicMock
+else:
+    from unittest.mock import patch, MagicMock
+
+
+def fake_py_dlt_client_main_loop(client, callback, *args, **kwargs):
+    return True
+
+
+@contextmanager
+def dlt_broker(pydlt_main_func=fake_py_dlt_client_main_loop, enable_dlt_time=True):
+    """Initialize a fake DLTBroker"""
+
+    with patch("dlt.dlt_broker_handlers.DLTMessageHandler._client_connect"), patch(
+        "dlt.dlt_broker_handlers.py_dlt_client_main_loop", side_effect=pydlt_main_func
+    ):
+        broker = DLTBroker("42.42.42.42", enable_dlt_time=enable_dlt_time)
+        broker.msg_handler._client = MagicMock()
+
+        broker.start()
+
+        yield broker
+
+        broker.stop()
+
+
+def test_start_stop_dlt_broker():
+    """Test to stop DLTBroker with dlt-time normally"""
+    with dlt_broker(fake_py_dlt_client_main_loop, enable_dlt_time=True) as broker:
+        assert_is_not_none(broker._dlt_time_value)
+
+
+def test_start_stop_dlt_broker_without_dlt_time():
+    """Test to stop DLTBroker without dlt-time normally"""
+    with dlt_broker(fake_py_dlt_client_main_loop, enable_dlt_time=False) as broker:
+        assert_is_none(broker._dlt_time_value)
+
+
+def test_dlt_broker_get_dlt_time():
+    """Test to get time from DLTBroker"""
+
+    def handle(client, callback=None, *args, **kwargs):
+        return callback(MockDLTMessage(payload="test_payload", sec=42, msec=42))
+
+    with dlt_broker(handle) as broker:
+        time.sleep(0.01)
+
+    assert abs(broker.dlt_time() - 42.42) <= 0.01
+
+
+def test_dlt_broker_get_latest_dlt_time():
+    """Test to get the latest time from DLTBroker"""
+    # ref: https://stackoverflow.com/questions/3190706/nonlocal-keyword-in-python-2-x
+    time_value = {"v": 42}
+
+    def handle(client, callback=None, *args, **kwargs):
+        if time_value["v"] < 45:
+            time_value["v"] += 1
+
+        time.sleep(0.01)
+        return callback(MockDLTMessage(payload="test_payload", sec=time_value["v"], msec=42))
+
+    with dlt_broker(handle) as broker:
+        time_vals = set()
+        for i in range(10):
+            time_vals.add(broker.dlt_time())
+            time.sleep(0.01)
+
+    expected_times = [0.0, 43.42, 44.42, 45.42]
+    error_value = (
+        abs(dlt_value - expected_value) <= 0.01 for dlt_value, expected_value in zip(sorted(time_vals), expected_times)
+    )
+    assert all(error_value)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -127,3 +127,40 @@ def create_messages(stream, from_file=False):
 
     msgs = load(tmpname)
     return msgs
+
+
+class MockDLTMessage(object):
+    """Mock DLT message for dltlyse plugin testing"""
+    def __init__(self, ecuid="MGHS", apid="SYS", ctid="JOUR", sid="958", payload="", tmsp=0.0, sec=0, msec=0, mcnt=0):
+        self.ecuid = ecuid
+        self.apid = apid
+        self.ctid = ctid
+        self.sid = sid
+        self.payload = payload
+        self.tmsp = tmsp
+        self.mcnt = mcnt
+        self.storageheader = MockStorageHeader(sec=sec, msec=msec)
+
+    def compare(self, target):
+        """Compare DLT Message to a dictionary"""
+        return target == {k: v for k, v in self.__dict__.items() if k in target.keys()}
+
+    @property
+    def payload_decoded(self):
+        """Fake payload decoding"""
+        return self.payload
+
+    @property
+    def storage_timestamp(self):
+        """Fake storage timestamp"""
+        return float("{}.{}".format(self.storageheader.seconds, self.storageheader.microseconds))
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+
+class MockStorageHeader(object):
+    """Mock DLT storage header for plugin testing"""
+    def __init__(self, msec=0, sec=0):
+        self.microseconds = msec
+        self.seconds = sec

--- a/tox.ini
+++ b/tox.ini
@@ -4,20 +4,19 @@ skipdist = True
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
+       parameterized
 commands = coverage erase
-           coverage run {envbindir}/nosetests {posargs}
+           coverage run {envbindir}/nosetests -sv {posargs}
            coverage report
 
 [testenv:py27]
 # Python 2.7 specific requirements
 deps = {[testenv]deps}
-       -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements2.7.txt
 
 [testenv:py3]
 # Python 3 specific requirements
 deps = {[testenv]deps}
-       -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements3.txt
 
 [testenv:lint]


### PR DESCRIPTION
There is an error between dlt message time and system time. For getting precise timestamp in message parsing, the patch adds a share memory to pass the timestamp from DLTMessageHandler to DLTBroker.

Please refer `dlt_broker.py` to get more implementation details and discussions.