### PR TITLE
Fix: pass dlt time with double to solve floating-point precision problem

### DIFF
--- a/dlt/dlt_broker_handlers.py
+++ b/dlt/dlt_broker_handlers.py
@@ -42,7 +42,7 @@ class DLTTimeValue(object):
     Pipe's implementation.
     """
     def __init__(self, default_value=0.0):
-        self._timestamp_mem = Value(ctypes.c_float, default_value)
+        self._timestamp_mem = Value(ctypes.c_double, default_value)
 
     @property
     def timestamp(self):


### PR DESCRIPTION
The float type in python is the double type in C. The previous implementation has the precision problem. Change it to `ctypes.c_dobule` to fix it