### PR TITLE
Update for dlt-daemon v2.18.8

### DIFF
--- a/.github/workflows/python-dlt-ci.yaml
+++ b/.github/workflows/python-dlt-ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         LIBDLT_VERSION:
-          - "33fbad18c814e13bd7ba2053525d8959fee437d1"
+          - "v2.18.8"
     steps:
       - uses: actions/checkout@v2
       - name: Build python-dlt unit test docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster as builder
 
-ARG LIBDLT_VERSION=v2.18.4
+ARG LIBDLT_VERSION=v2.18.8
 
 RUN set -ex \
     && apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Non released dlt-daemon version based on 2.18.5
-LIBDLT_VERSION=33fbad18c814e13bd7ba2053525d8959fee437d1
+# Non released dlt-daemon version based on 2.18.8
+LIBDLT_VERSION=v2.18.8
 
 IMAGE=python-dlt/python-dlt-unittest
 TAG?=latest

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ primarily created for use with BMW's test execution framework. However,
 the implementation is independent and the API makes few assumptions about
 the intended use.
 
-Note: This is only tested with libdlt version v2.18.5 (33fbad18c814e13bd7ba2053525d8959fee437d1),
+Note: This is only tested with libdlt version v2.18.5 (33fbad18c814e13bd7ba2053525d8959fee437d1) and v2.18.8,
 later versions might require adaptations. The package will not support previous libdlt
 versions from python-dlt v2.0. Also only GENIVI DLT daemon produced traces
 have been tested.

--- a/dlt/core/core_2188.py
+++ b/dlt/core/core_2188.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2022. BMW CTW PT. All rights reserved.
+"""v2.18.8 specific class definitions"""
+import ctypes
+import logging
+import six
+
+from .core_base import dltlib
+
+# DltClientMode from dlt_client.h
+DLT_CLIENT_MODE_UNDEFINED = -1
+DLT_CLIENT_MODE_TCP = 0
+DLT_CLIENT_MODE_SERIAL = 1
+DLT_CLIENT_MODE_UNIX = 2
+DLT_CLIENT_MODE_UDP_MULTICAST = 3
+
+# DltReceiverType from dlt_common.h
+DLT_RECEIVE_SOCKET = 0
+DLT_RECEIVE_UDP_SOCKET = 1
+DLT_RECEIVE_FD = 2
+DLT_ID_SIZE = 4
+DLT_FILTER_MAX = 30  # Maximum number of filters
+DLT_RETURN_ERROR = -1
+
+# Return value for DLTFilter.add() - exceeded maximum number of filters
+MAX_FILTER_REACHED = 1
+# Return value for DLTFilter.add() - specified filter already exists
+REPEATED_FILTER = 2
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class sockaddr_in(ctypes.Structure):  # pylint: disable=invalid-name
+    """Auxiliary definition for cDltReceiver. Defined in netinet/in.h header"""
+
+    _fields_ = [
+        ("sa_family", ctypes.c_ushort),  # sin_family
+        ("sin_port", ctypes.c_ushort),
+        ("sin_addr", ctypes.c_byte * 4),
+        ("__pad", ctypes.c_byte * 8),
+    ]  # struct sockaddr_in is 16
+
+
+class cDltReceiver(ctypes.Structure):  # pylint: disable=invalid-name
+    """The structure is used to organise the receiving of data including buffer handling.
+    This structure is used by the corresponding functions.
+
+    typedef struct
+    {
+        int32_t lastBytesRcvd;    /**< bytes received in last receive call */
+        int32_t bytesRcvd;        /**< received bytes */
+        int32_t totalBytesRcvd;   /**< total number of received bytes */
+        char *buffer;             /**< pointer to receiver buffer */
+        char *buf;                /**< pointer to position within receiver buffer */
+        char *backup_buf;         /** pointer to the buffer with partial messages if any **/
+        int fd;                   /**< connection handle */
+        DltReceiverType type;     /**< type of connection handle */
+        int32_t buffersize;       /**< size of receiver buffer */
+        struct sockaddr_in addr;  /**< socket address information */
+    } DltReceiver;
+    """
+
+    _fields_ = [("lastBytesRcvd", ctypes.c_int32),
+                ("bytesRcvd", ctypes.c_int32),
+                ("totalBytesRcvd", ctypes.c_int32),
+                ("buffer", ctypes.POINTER(ctypes.c_char)),
+                ("buf", ctypes.POINTER(ctypes.c_char)),
+                ("backup_buf", ctypes.POINTER(ctypes.c_char)),
+                ("fd", ctypes.c_int),
+                ("type", ctypes.c_int),
+                ("buffersize", ctypes.c_int32),
+                ("addr", sockaddr_in)]
+
+
+class cDltClient(ctypes.Structure):  # pylint: disable=invalid-name
+    """
+    typedef struct
+    {
+        DltReceiver receiver;      /**< receiver pointer to dlt receiver structure */
+        int sock;                  /**< sock Connection handle/socket */
+        char *servIP;              /**< servIP IP adress/Hostname of TCP/IP interface */
+        char *hostip;              /**< IP multicast address of group */
+        int port;                  /**< Port for TCP connections (optional) */
+        char *serialDevice;        /**< serialDevice Devicename of serial device */
+        char *socketPath;          /**< socketPath Unix socket path */
+        char ecuid[4];             /**< ECUiD */
+        speed_t baudrate;          /**< baudrate Baudrate of serial interface, as speed_t */
+        DltClientMode mode;        /**< mode DltClientMode */
+        int send_serial_header;    /**< (Boolean) Send DLT messages with serial header */
+        int resync_serial_header;  /**< (Boolean) Resync to serial header on all connection */
+    } DltClient;
+    """
+
+    _fields_ = [
+        ("receiver", cDltReceiver),
+        ("sock", ctypes.c_int),
+        ("servIP", ctypes.c_char_p),
+        ("hostip", ctypes.c_char_p),
+        ("port", ctypes.c_int),
+        ("serialDevice", ctypes.c_char_p),
+        ("socketPath", ctypes.c_char_p),
+        ("ecuid", ctypes.c_char * 4),
+        ("baudrate", ctypes.c_uint),
+        ("mode", ctypes.c_int),
+        ("send_serial_header", ctypes.c_int),
+        ("resync_serial_header", ctypes.c_int),
+    ]
+
+
+class cDLTFilter(ctypes.Structure):  # pylint: disable=invalid-name
+    """
+    typedef struct
+    {
+        char apid[DLT_FILTER_MAX][DLT_ID_SIZE]; /**< application id */
+        char ctid[DLT_FILTER_MAX][DLT_ID_SIZE]; /**< context id */
+        int log_level[DLT_FILTER_MAX];          /**< log level */
+        int32_t payload_max[DLT_FILTER_MAX];    /**< upper border for payload */
+        int32_t payload_min[DLT_FILTER_MAX];    /**< lower border for payload */
+        int  counter;                           /**< number of filters */
+    } DltFilter;
+    """
+
+    _fields_ = [
+        ("apid", (ctypes.c_char * DLT_ID_SIZE) * DLT_FILTER_MAX),
+        ("ctid", (ctypes.c_char * DLT_ID_SIZE) * DLT_FILTER_MAX),
+        ("log_level", ctypes.c_int * DLT_FILTER_MAX),
+        ("payload_max", (ctypes.c_int32 * DLT_FILTER_MAX)),
+        ("payload_min", (ctypes.c_int32 * DLT_FILTER_MAX)),
+        ("counter", ctypes.c_int),
+    ]
+
+    # pylint: disable=too-many-arguments
+    def add(self, apid, ctid, log_level=0, payload_min=0, payload_max=ctypes.c_uint32(-1).value // 2):
+        """Add new filter pair"""
+        if six.PY3:
+            if isinstance(apid, str):
+                apid = bytes(apid, "ascii")
+            if isinstance(ctid, str):
+                ctid = bytes(ctid, "ascii")
+        if (
+                dltlib.dlt_filter_add(
+                    ctypes.byref(self), apid or b"", ctid or b"", log_level, payload_min, payload_max, self.verbose
+                )
+                == DLT_RETURN_ERROR
+        ):
+            if self.counter >= DLT_FILTER_MAX:
+                logger.error("Maximum number (%d) of allowed filters reached, ignoring filter!\n", DLT_FILTER_MAX)
+                return MAX_FILTER_REACHED
+            logger.debug("Filter ('%s', '%s') already exists", apid, ctid)
+            return REPEATED_FILTER
+        return 0

--- a/dlt/dlt.py
+++ b/dlt/dlt.py
@@ -16,8 +16,8 @@ import threading
 import six
 
 from dlt.core import (
-    dltlib, DLT_CLIENT_MODE_UDP_MULTICAST, DLT_ID_SIZE, DLT_HTYP_WEID, DLT_HTYP_WSID, DLT_HTYP_WTMS,
-    DLT_HTYP_UEH, DLT_RETURN_OK, DLT_RETURN_ERROR, DLT_RETURN_TRUE, DLT_FILTER_MAX, DLT_MESSAGE_ERROR_OK,
+    cDLTFilter, dltlib, DLT_CLIENT_MODE_UDP_MULTICAST, DLT_ID_SIZE, DLT_HTYP_WEID, DLT_HTYP_WSID, DLT_HTYP_WTMS,
+    DLT_HTYP_UEH, DLT_RETURN_OK, DLT_RETURN_ERROR, DLT_RETURN_TRUE, DLT_MESSAGE_ERROR_OK,
     cDltExtendedHeader, cDltClient, MessageMode, cDLTMessage, cDltStorageHeader, cDltStandardHeader,
     DLT_TYPE_INFO_UINT, DLT_TYPE_INFO_SINT, DLT_TYPE_INFO_STRG, DLT_TYPE_INFO_SCOD,
     DLT_TYPE_INFO_TYLE, DLT_TYPE_INFO_VARI, DLT_TYPE_INFO_RAWD,
@@ -34,10 +34,6 @@ except Exception:  # pylint: disable=broad-except
     pass
 
 MAX_LOG_IN_ROW = 3
-# Return value for DLTFilter.add() - exceeded maximum number of filters
-MAX_FILTER_REACHED = 1
-# Return value for DLTFilter.add() - specified filter already exists
-REPEATED_FILTER = 2
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 DLT_EMPTY_FILE_ERROR = "DLT TRACE FILE IS EMPTY"
@@ -64,21 +60,10 @@ class cached_property(object):  # pylint: disable=invalid-name
         return value
 
 
-class DLTFilter(ctypes.Structure):
+class DLTFilter(cDLTFilter):
     """Structure to store filter parameters. ID are maximal four characters. Unused values are filled with zeros.
     If every value as filter is valid, the id should be empty by having only zero values.
-
-    typedef struct
-    {
-        char apid[DLT_FILTER_MAX][DLT_ID_SIZE]; /**< application id */
-        char ctid[DLT_FILTER_MAX][DLT_ID_SIZE]; /**< context id */
-        int  counter;                           /**< number of filters */
-    } DltFilter;
     """
-
-    _fields_ = [("apid", (ctypes.c_char * DLT_ID_SIZE) * DLT_FILTER_MAX),
-                ("ctid", (ctypes.c_char * DLT_ID_SIZE) * DLT_FILTER_MAX),
-                ("counter", ctypes.c_int)]
 
     verbose = 0
 
@@ -91,21 +76,6 @@ class DLTFilter(ctypes.Structure):
     def __del__(self):
         if dltlib.dlt_filter_free(ctypes.byref(self), self.verbose) == DLT_RETURN_ERROR:
             raise RuntimeError("Could not cleanup DLTFilter")
-
-    def add(self, apid, ctid):
-        """Add new filter pair"""
-        if six.PY3:
-            if isinstance(apid, str):
-                apid = bytes(apid, "ascii")
-            if isinstance(ctid, str):
-                ctid = bytes(ctid, "ascii")
-        if dltlib.dlt_filter_add(ctypes.byref(self), apid or b"", ctid or b"", self.verbose) == DLT_RETURN_ERROR:
-            if self.counter >= DLT_FILTER_MAX:
-                logger.error("Maximum number (%d) of allowed filters reached, ignoring filter!\n", DLT_FILTER_MAX)
-                return MAX_FILTER_REACHED
-            logger.debug("Filter ('%s', '%s') already exists", apid, ctid)
-            return REPEATED_FILTER
-        return 0
 
     def __repr__(self):
         """return the 'official' string representation of an object"""
@@ -421,13 +391,22 @@ class DLTMessage(cDLTMessage, MessageMode):
             return self.apid == other.apid and self.ctid == other.ctid and self.__eq__(other)
 
         # pylint: disable=protected-access
-        if hasattr(other, "_fields_") and [x[0] for x in other._fields_] == ["apid", "ctid", "counter"]:
+        if hasattr(other, "_fields_") and [x[0] for x in other._fields_] == [
+                "apid",
+                "ctid",
+                "log_level",
+                "payload_max",
+                "payload_min",
+                "counter",
+        ]:
             # other id DLTFilter
             return dltlib.dlt_message_filter_check(ctypes.byref(self), ctypes.byref(other), 0)
 
         if not isinstance(other, dict):
-            raise TypeError("other must be instance of mgu_dlt.dlt.DLTMessage, mgu_dlt.dlt.DLTFilter or a dictionary"
-                            " found: {}".format(type(other)))
+            raise TypeError(
+                "other must be instance of dlt.dlt.DLTMessage, dlt.dlt.DLTFilter or a dictionary"
+                " found: {}".format(type(other))
+            )
 
         other = other.copy()
         apid = other.get("apid", None)
@@ -906,11 +885,6 @@ class DLTClient(cDltClient):
         # it ourselves elsewhere
         self.port = kwords.get("port", DLT_DAEMON_TCP_PORT)
 
-    def __del__(self):
-        if dltlib.dlt_client_cleanup(ctypes.byref(self), self.verbose) == DLT_RETURN_ERROR:
-            raise RuntimeError("Could not cleanup DLTClient")
-        self.disconnect()
-
     def connect(self, timeout=None):
         """Connect to the server
 
@@ -964,6 +938,8 @@ class DLTClient(cDltClient):
 
     def disconnect(self):
         """Close all sockets"""
+        if dltlib.dlt_client_cleanup(ctypes.byref(self), self.verbose) == DLT_RETURN_ERROR:
+            raise RuntimeError("Could not cleanup DLTClient")
         if self._connected_socket:
             try:
                 self._connected_socket.shutdown(socket.SHUT_RDWR)

--- a/dlt/dlt_broker_handlers.py
+++ b/dlt/dlt_broker_handlers.py
@@ -37,10 +37,11 @@ class DLTTimeValue(object):
     variable. The solution based on Value does not have such problem, only
     assigns the value to the shared memory directly.
 
-    khiz678 also did a simple benchamrk for the Value soltuion. It could
-    receive more than 100000 timestamps per seocnd.  It's twice faster than
+    khiz678 also did a simple benchmark for the Value solution. It could
+    receive more than 100000 timestamps per second.  It's twice faster than
     Pipe's implementation.
     """
+
     def __init__(self, default_value=0.0):
         self._timestamp_mem = Value(ctypes.c_double, default_value)
 
@@ -335,4 +336,5 @@ class DLTMessageHandler(Process):
                     self._client.disconnect()
 
         self.message_queue.close()
+        self._client.disconnect()
         logger.info("DLTMessageHandler worker execution complete")

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ max-line-length = 119
 
 [TYPECHECK]
 disable=bad-option-value
+ignored-classes=socket,struct
 
 [MESSAGES CONTROL]
 

--- a/tests/dlt_core_unit_tests.py
+++ b/tests/dlt_core_unit_tests.py
@@ -21,8 +21,9 @@ class TestCoreStructures(unittest.TestCase):
                          'cDltStandardHeaderExtra': 12,
                          'cDltExtendedHeader': 10,
                          'cDLTMessage': 120,
-                         'cDltReceiver': 64,
-                         'cDltClient': 128}
+                         'cDltReceiver': 72,
+                         'cDltClient': 144,
+                         'cDLTFilter': 604}
 
     def test_sizeof(self):
         for clsname, expected in self.size_map.items():

--- a/tests/dlt_filter_unit_tests.py
+++ b/tests/dlt_filter_unit_tests.py
@@ -7,8 +7,8 @@ import ctypes
 
 from nose.tools import *
 
-from dlt.dlt import DLTFilter, DLT_FILTER_MAX, DLT_ID_SIZE
-
+from dlt.dlt import DLTFilter
+from dlt.core.core_base import DLT_FILTER_MAX, DLT_ID_SIZE
 
 class TestDLTFilter(object):
 
@@ -30,7 +30,7 @@ class TestDLTFilter(object):
             assert_true(ctypes.string_at(entry, DLT_ID_SIZE) == b"\0\0\0\0")
 
     def test_add0(self):
-        self.dlt_filter.add("AAA", "BBB")
+        assert_equal(self.dlt_filter.add("AAA", "BBB"), 0)
         assert_equal(self.dlt_filter.counter, 1)
         assert_equal(len(self.dlt_filter.apid[0]), 4)
         assert_equal(len(self.dlt_filter.ctid[0]), 4)
@@ -38,8 +38,8 @@ class TestDLTFilter(object):
         assert_true(ctypes.string_at(self.dlt_filter.ctid[0], DLT_ID_SIZE) == b"BBB\0")
 
     def test_add1(self):
-        self.dlt_filter.add("AAA", "BBB")
-        self.dlt_filter.add("XXX", "YYY")
+        assert_equal(self.dlt_filter.add("AAA", "BBB"), 0)
+        assert_equal(self.dlt_filter.add("XXX", "YYY"), 0)
         assert_equal(self.dlt_filter.counter, 2)
         assert_true(ctypes.string_at(self.dlt_filter.apid[0], DLT_ID_SIZE) == b"AAA\0")
         assert_true(ctypes.string_at(self.dlt_filter.ctid[0], DLT_ID_SIZE) == b"BBB\0")
@@ -47,9 +47,9 @@ class TestDLTFilter(object):
         assert_true(ctypes.string_at(self.dlt_filter.ctid[1], DLT_ID_SIZE) == b"YYY\0")
 
     def test_add2(self):
-        self.dlt_filter.add("AAAA", "BBBB")
-        self.dlt_filter.add("XXX", "YYY")
-        self.dlt_filter.add("CCCC", "DDDD")
+        assert_equal(self.dlt_filter.add("AAAA", "BBBB"), 0)
+        assert_equal(self.dlt_filter.add("XXX", "YYY"), 0)
+        assert_equal(self.dlt_filter.add("CCCC", "DDDD"), 0)
         assert_equal(self.dlt_filter.counter, 3)
         assert_true(ctypes.string_at(self.dlt_filter.apid[0], DLT_ID_SIZE) == b"AAAA")
         assert_true(ctypes.string_at(self.dlt_filter.ctid[0], DLT_ID_SIZE) == b"BBBB")
@@ -59,8 +59,8 @@ class TestDLTFilter(object):
         assert_true(ctypes.string_at(self.dlt_filter.ctid[2], DLT_ID_SIZE) == b"DDDD")
 
     def test_repr(self):
-        self.dlt_filter.add("AAAA", "BBBB")
-        self.dlt_filter.add("XXX", "YYY")
-        self.dlt_filter.add("CCCC", "DDDD")
+        assert_equal(self.dlt_filter.add("AAAA", "BBBB"), 0)
+        assert_equal(self.dlt_filter.add("XXX", "YYY"), 0)
+        assert_equal(self.dlt_filter.add("CCCC", "DDDD"), 0)
         print(self.dlt_filter)
         assert_true(str(self.dlt_filter) == str([(b"AAAA", b"BBBB"), (b"XXX", b"YYY"), (b"CCCC", b"DDDD")]))


### PR DESCRIPTION
- Create new core_2188 to handle new version
- Updated unittests
- switch CI to v2.18.8
- python_dlt is now able to use dlt-daemon lib compiled for MAC OSX
- moved DltFilter C structure to core layer