### PR TITLE
Configure tox/pytest to capture warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,10 @@ commands =
         --cov-report=term-missing \
         {posargs:tests}
 
+[pytest]
+filterwarnings =
+    error
+
 [testenv:lint]
 skip_install = True
 skipsdist = True


### PR DESCRIPTION
Capture all unit/functional tests warnings and turn them into errors