### PR TITLE
doc: fix example of DLTFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Here are examples of some interesting ways to use these classes:
 
 ```python
     >>> from dlt import dlt
-    >>> # DLTFile object can be obtained by lading a trace file
+    >>> # DLTFile object can be obtained by loading a trace file
     >>> d = dlt.load("high_full_trace.dlt")
+    >>> d.generate_index()      # Read the whole trace file and generate its index
     >>> print(d.counter_total)  # number of DLT messages in the file
     ...
     >>> print(d[0])             # messages can be indexed


### PR DESCRIPTION
Thanks for the useful package!

I've encountered little trouble that `counter_total` was 0 when I tried `python-dlt` based on README example.

It's because the example doesn't call `generate_index()`.
I know it's called implicitly in almost cases.
But the example reads `counter_total` immediately after `load`
therefore I think we need to call `generate_index()` explicitly in this case.

In addition, I've fixed tiny typo ("loading") in this PR.